### PR TITLE
Collection: Get multiple items by key

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -71,16 +71,28 @@ class Collection implements Countable, ArrayAccess, IteratorAggregate, Serializa
     /**
      * Get an item from the collection. Returns $default if item cannot be found.
      *
-     * @param string $key
+     * Passing an array of item keys for the value of $key will result in multiple
+     * items being returned. Keys that are missing from the collection will be
+     * returned with a value of $default.
+     *
+     * @param mixed $key
      * @param mixed $default
      * @return mixed Will return $default if cannot find item
      */
     public function get($key, $default = null)
     {
-        if (isset($this->items[$key])) {
-            return $this->items[$key];
+        if (is_array($key)) {
+            // Get multiple items by their key
+            $items = [];
+            foreach ($key as $k) {
+                $items[$k] = isset($this->items[$k]) ? $this->items[$k] : $default;
+            }
+
+            return $items;
+        } else {
+            // Get a single item by its key
+            return isset($this->items[$key]) ? $this->items[$key] : $default;
         }
-        return $default;
     }
 
     /**

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -221,4 +221,19 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
         unset($collection['key1']);
         $this->assertFalse($collection->has('key1'));
     }
+
+    /**
+     * @covers Collection::get
+     */
+    public function testGetMultipleItems()
+    {
+        $collection = new Collection(['key1' => 'value1', 'key2' => 'value2']);
+        $values = $collection->get(['key1', 'key2', 'key3']);
+
+        $this->assertTrue(array_key_exists('key1', $values) && $values['key1'] == 'value1');
+        $this->assertTrue(array_key_exists('key2', $values) && $values['key2'] == 'value2');
+
+        // Assert the key3 equals the default (null)
+        $this->assertTrue(array_key_exists('key3', $values) && $values['key3'] == null);
+    }
 }


### PR DESCRIPTION
Updated the `get()` in Collection to accept an array of keys for the first argument. 