### PR TITLE
Add Arr::dot method

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,3 +253,7 @@ A helper library for working with arrays.
 ##### `static flatten(array $array, string $separator = '.', string $prepend = '') : array`
 
 Flatten an associative array using a custom separator.
+
+##### `static dot(array $array) : array`
+
+Flatten an associative array using a dot (.) separator.

--- a/src/Arr.php
+++ b/src/Arr.php
@@ -32,4 +32,15 @@ class Arr
 
         return $flatArray;
     }
+
+    /**
+     * Flatten an associative array using a dot (.) separator.
+     *
+     * @param array $array
+     * @return array
+     */
+    public static function dot(array $array): array
+    {
+        return self::flatten($array);
+    }
 }


### PR DESCRIPTION
Add `Arr::dot()` which flattens an array using dot (.) notation. This method simply calls existing `Arr::flatten()` with it's default arguments.